### PR TITLE
Adds cache TTL feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It's useful when the output of a command executed by `in_exec` only returns the 
       key  unique_id # required
       file /tmp/dedup_state.json # optional. If set, saves the state to the file.
       cache_per_tag 10 # optional. If set, recent logs up to this number is cached.
+      cache_ttl 600 # optional. If set, cache entries is expired in this TTL.
     </match>
 
     <match dedup.some.thing>
@@ -33,6 +34,8 @@ All logs that are processed by this plugin will have tag prefix `dedup`.
 If the optional `file` parameter is set, it dumps the state during shutdown and loads on start, so that it can still dedup after reload.
 
 If the optional `cache_per_tag` is set, it caches N recently appeared logs (only caches `unique_id` in this example) and compared to new logs.
+
+If the optional `cache_ttl` is set, it evicts cache entries in a specific amount of time.
 
 ## Testing
 

--- a/fluent-plugin-dedup.gemspec
+++ b/fluent-plugin-dedup.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.0"
+  spec.add_development_dependency "timecop"
 
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "lru_redux"

--- a/lib/fluent/plugin/out_dedup.rb
+++ b/lib/fluent/plugin/out_dedup.rb
@@ -7,6 +7,7 @@ class Fluent::DedupOutput < Fluent::Output
   config_param :key, :string, :default => nil
   config_param :file, :string, :default => nil
   config_param :cache_per_tag, :size, :default => 1
+  config_param :cache_ttl, :integer, :default => 0
 
   # Define `log` method for v0.10.42 or earlier
   unless method_defined?(:log)
@@ -82,6 +83,10 @@ class Fluent::DedupOutput < Fluent::Output
   end
 
   def new_lru
-    LruRedux::ThreadSafeCache.new(@cache_per_tag)
+    if 0 < @cache_ttl
+      LruRedux::TTL::ThreadSafeCache.new(@cache_per_tag, @cache_ttl)
+    else
+      LruRedux::ThreadSafeCache.new(@cache_per_tag)
+    end
   end
 end

--- a/test/fluent/plugin/test_out_dedup.rb
+++ b/test/fluent/plugin/test_out_dedup.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'timecop'
 
 class DedupOutputTest < Test::Unit::TestCase
   def setup
@@ -108,6 +109,31 @@ class DedupOutputTest < Test::Unit::TestCase
       assert_equal 2, d.emits.length
       assert_equal '1', d.emits[0][2]['unique_id']
       assert_equal '2', d.emits[1][2]['unique_id']
+    end
+  end
+
+  sub_test_case '`cache_ttl` parameter is present' do
+    test "a record identical to most recent N records is suppressed with TTL option" do
+      config = %[
+        key           unique_id
+        cache_per_tag 2
+        cache_ttl     60
+      ]
+
+      d = create_driver(config)
+      d.run do
+        d.emit({'unique_id' => '1'}, Time.now)
+        d.emit({'unique_id' => '1'}, Time.now) # dup
+        d.emit({'unique_id' => '2'}, Time.now)
+        d.emit({'unique_id' => '1'}, Time.now) # dup
+        Timecop.freeze(Time.now + 61)
+        d.emit({'unique_id' => '1'}, Time.now) # no dup since expired
+      end
+
+      assert_equal 3, d.emits.length
+      assert_equal '1', d.emits[0][2]['unique_id']
+      assert_equal '2', d.emits[1][2]['unique_id']
+      assert_equal '1', d.emits[2][2]['unique_id']
     end
   end
 end


### PR DESCRIPTION
Even if it's the identical repeated record, it is helpful to emit again after specific time of amount in some cases like handling error logs to notify a warning alert to a chat room.
