### PR TITLE
fix error in fluentd 1.x

### DIFF
--- a/lib/fluent/plugin/out_dedup.rb
+++ b/lib/fluent/plugin/out_dedup.rb
@@ -37,7 +37,7 @@ class Fluent::DedupOutput < Fluent::Output
   def emit(tag, es, chain)
     es.each do |time, record|
       next if dup?(tag, record)
-      Fluent::Engine.emit("dedup.#{tag}", time, record)
+      router.emit("dedup.#{tag}", time, record)
     end
 
     chain.next


### PR DESCRIPTION
This resolves the following error when used with fluentd `1.12.0`:

```
fluent/log.rb:350:warn: emit transaction failed: error_class=RuntimeError error="BUG: use router.emit instead of Engine.emit" location="/usr/lib/ruby/gems/2.7.0/gems/fluentd-1.12.0/lib/fluent/engine.rb:124:in `emit'"
```